### PR TITLE
Fix UnboundLocalError thrown during training

### DIFF
--- a/NewsSentiment/train.py
+++ b/NewsSentiment/train.py
@@ -692,6 +692,7 @@ class Instructor:
         t_outputs_all = None
         t_text_bert_indices_targets_mask_all = None
         t_texts_all = []
+        t_outputs_confidence = None
 
         # switch model to evaluation mode
         self.own_model.eval()


### PR DESCRIPTION
NewsSentiment/train.py --own_model_name grutsc --dataset_name newsmtsc-rw threw this error after some time during training:

```
Traceback (most recent call last):
  File "NewsSentiment/train.py", line 1379, in <module>
    prepare_and_start_instructor(opt)
  File "NewsSentiment/train.py", line 1206, in prepare_and_start_instructor
    ins.run()
  File "NewsSentiment/train.py", line 866, in run
    criterion, optimizer, train_data_loader, dev_data_loader
  File "NewsSentiment/train.py", line 504, in _train
    selected_model_dev_stats,
  File "NewsSentiment/train.py", line 526, in _intraining_evaluation_and_model_save
    dev_stats = self._evaluate(dev_data_loader)
  File "NewsSentiment/train.py", line 767, in _evaluate
    stats = self.evaluator.calc_statistics(y_true, y_pred, t_outputs_confidence)
UnboundLocalError: local variable 't_outputs_confidence' referenced before assignment
```

Looks like an oversight when this variable was introduced in  213c1da0 as in some circumstances this variable can be referenced before assignment.