### PR TITLE
Update dependencies to work with torch 1.13

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,8 +46,8 @@ install_requires =
     spacy>=3.2
     tabulate>=0.8.9
     tqdm>=4.62.3
-    transformers==4.17.0
-    torch==1.11.0
+    transformers>=4.17.0,<=4.24.0
+    torch>=1.12.0,<1.14.0
 
 [options.packages.find]
 where = .


### PR DESCRIPTION
Torch 1.13 and transformers <=4.24.0 seem to introduce no breaking changes for this repo. It should thus be safe to update these dependencies.