### PR TITLE
Raise requirements

### DIFF
--- a/NewsSentiment/train.py
+++ b/NewsSentiment/train.py
@@ -390,7 +390,7 @@ class Instructor:
                 for i_batch, sample_batched in enumerate(train_data_loader):
                     global_step += 1
                     # clear gradient accumulators
-                    optimizer.zero_grad()
+                    optimizer.zero_grad(set_to_none = False)
                     # select only relevant fields
                     inputs = self.select_inputs(sample_batched)
                     targets = sample_batched["polarity"].to(self.opt.device)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ virtualenv -ppython3.8 --setuptools 45 venv
 source venv/bin/activate
 ```
 
+Note: We recommend Python 3.8, however we have successfully tested NewsMTSC with Python version >=3.8, <3.12.
+
 **2. Setup NewsMTSC:**
 ```bash
 git clone git@github.com:fhamborg/NewsMTSC.git

--- a/pythoninfo.md
+++ b/pythoninfo.md
@@ -1,7 +1,8 @@
-This step is optional if you have Python 3.8 installed (run `python --version`
-in a terminal and check the version that is printed). If you don't have Python 3.8, we
-recommend using Anaconda for setting up requirements because it is very easy (but any way
-of installing Python 3.8 is fine). If you do not have Anaconda yet, follow their
+This step is optional if you have Python >=3.8, <3.12 installed (run `python --version`
+in a terminal and check the version that is printed; we recommend 3.8). If you don't
+have Python (in the correct version), we recommend using Anaconda for setting up
+requirements because it is very easy (but any way of installing is fine).
+If you do not have Anaconda yet, follow their
 [installation instructions](https://docs.anaconda.com/anaconda/install/).
 
 After installing Anaconda, to set up a Python 3.8 environment (in case you don't have one

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,8 +45,8 @@ install_requires =
     spacy>=3.2
     tabulate>=0.8.9
     tqdm>=4.62.3
-    transformers>=4.17.0,<=4.24.0
-    torch>=1.12.0,<1.14.0
+    transformers>=4.17,<=4.24
+    torch>=1.12,<2.1
 
 [options.packages.find]
 where = .

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,9 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Intended Audience :: Developers
     Intended Audience :: Science/Research
     Topic :: Scientific/Engineering
@@ -27,7 +30,7 @@ classifiers =
 package_dir =
     = .
 packages = find_namespace:
-python_requires = ==3.8.*
+python_requires = >=3.8, <3.12
 # include_package_data = true
 install_requires =
     boto3>=1.19.7


### PR DESCRIPTION
Raise upper bounds to python (<3.12) and torch (<2.1). Successfully tested train and infer.